### PR TITLE
Fix SIMD learn more link and small tweaks

### DIFF
--- a/_static/prism-duotone-light.css
+++ b/_static/prism-duotone-light.css
@@ -32,13 +32,13 @@ pre[class*="language-"] {
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
   text-shadow: none;
-  background: rgb(250, 250, 250);
+  background: rgb(230, 230, 230);
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
   text-shadow: none;
-  background: rgb(250, 250, 250);
+  background: rgb(230, 230, 230);
 }
 
 /* Code blocks */

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 
     <nav class="navbar navbar-expand-lg">
       <div class="navbar-brand">
-        <img src="_static/numba-blue-icon-rgb.svg" style="height: 2rem;">
+        <img src="_static/numba-blue-icon-rgb.svg" style="height: 2rem;" alt="Numba logo">
       </div>
       <div class="navbar-light bg-light">
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
@@ -55,10 +55,10 @@
           <li class="navbar-item"><a class="nav-link" href="http://numba.pydata.org/numba-doc/latest/user/talks.html">Talks/Tutorials</a></li>
 
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Community
             </a>
-            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink2">
               <a class="dropdown-item" href="https://github.com/numba/numba">Github</a>
               <a class="dropdown-item" href="https://pypi.org/project/numba/">PyPI</a>
               <a class="dropdown-item" href="https://gitter.im/numba/numba">Gitter Chat</a>
@@ -72,7 +72,7 @@
 
     <div class="hero position-relative overflow-hidden p-3 text-center text-dark">
       <div class="col-md-5 p-lg-1 mx-auto my-5">
-        <img src="_static/numba-blue-horizontal-rgb.svg" style="max-width: 30rem;">
+        <img src="_static/numba-blue-horizontal-rgb.svg" style="max-width: 30rem;" alt="Numba logo">
 		  <p class="lead font-weight-normal">
         Numba makes Python code fast
       </p>
@@ -87,7 +87,7 @@
       <div class="product-device product-device-2 box-shadow d-none d-md-block"></div>
     </div>
 
-
+    </header>
     <main role="main">
 
       <!-- Wrap the rest of the page in another container to center all the content. -->
@@ -104,7 +104,7 @@
             <a class="btn btn-outline-secondary" href="http://numba.pydata.org/numba-doc/latest/user/jit.html" role="button">Learn More &raquo;</a>
             <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/numba/numba-examples/master?filepath=notebooks%2Fbasics.ipynb" role="button">Try Now &raquo;</a>
           </div>
-        
+
           <div class="col-md-5 code-block">
             <pre><code class="language-python">from numba import jit
 import random
@@ -115,7 +115,7 @@ def monte_carlo_pi(nsamples):
     for i in range(nsamples):
         x = random.random()
         y = random.random()
-        if (x**2 + y**2) < 1.0:
+        if (x ** 2 + y ** 2) < 1.0:
             acc += 1
     return 4.0 * acc / nsamples</code></pre>
           </div>
@@ -173,14 +173,14 @@ def simulator(out):
 	vaddps	%ymm2, %ymm2, %ymm2</code></pre>
             <p>Numba can automatically translate some loops into vector instructions for 2-4x speed improvements.  Numba adapts to your CPU capabilities, whether your CPU supports SSE, AVX, or AVX-512.</p>
             <p>
-              <a class="btn btn-outline-secondary" href="" role="button">Learn More &raquo;</a>
+              <a class="btn btn-outline-secondary" href="http://numba.pydata.org/numba-doc/latest/user/performance-tips.html" role="button">Learn More &raquo;</a>
               <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/numba/numba-examples/master?filepath=notebooks%2Fsimd.ipynb" role="button">Try Now &raquo;</a>
             </p>
           </div><!-- /.col-lg-4 -->
           <div class="col-lg-4">
             <h2 class="mt-3">GPU Acceleration</h2>
-            <img src="_static/nvidia_cuda.jpg" class="top-image">
-            <img src="_static/amd_rocm.png" class="top-image">
+            <img src="_static/nvidia_cuda.jpg" class="top-image" alt="NVIDIA CUDA logo">
+            <img src="_static/amd_rocm.png" class="top-image" alt="AMD ROCm logo">
             <p>With support for both NVIDIA's CUDA and AMD's ROCm drivers, Numba lets you write parallel GPU algorithms entirely from Python.</p>
             <p>
               <a class="btn btn-outline-secondary" href="http://numba.pydata.org/numba-doc/latest/cuda/index.html" role="button">Numba CUDA &raquo;</a>
@@ -199,7 +199,7 @@ def simulator(out):
             <p class="lead">Numba supports Intel and AMD x86, POWER8/9, and ARM CPUs, NVIDIA and  AMD GPUs, Python 2.7 and 3.4-3.7, as well as Windows/macOS/Linux.  Precompiled Numba binaries for most systems are available as conda packages and pip-installable wheels.</p>
             <a class="btn btn-outline-secondary" href="http://numba.pydata.org/numba-doc/latest/user/installing.html" role="button">Learn More &raquo;</a>
           </div>
-
+        </div>
       </div>
 
       <hr class="featurette-divider">
@@ -211,24 +211,24 @@ def simulator(out):
           <p>Numba development is made possible through the current and/or past support of a number of organizations:<p>
           <div class="row">
             <div class="col supporter">
-              <a href="https://anaconda.com"><img src="_static/anaconda_logo.png"></a>
+              <a href="https://anaconda.com"><img src="_static/anaconda_logo.png" alt="Anaconda logo"></a>
             </div>
             <div class="col supporter">
-              <a href="https://www.darpa.mil"><img src="_static/darpa_logo.png"></a>
+              <a href="https://www.darpa.mil"><img src="_static/darpa_logo.png" alt="DARPA logo"></a>
             </div>
             <div class="col supporter">
-              <a href="https://www.moore.org/grant-detail?grantId=GBMF5423"><img src="_static/moore_logo.png"></a>
+              <a href="https://www.moore.org/grant-detail?grantId=GBMF5423"><img src="_static/moore_logo.png" alt="Moore foundation logo"></a>
             </div>
           </div>
           <div class="row">
             <div class="col supporter">
-              <a href="https://www.intel.com"><img src="_static/intel_logo.png"></a>
+              <a href="https://www.intel.com"><img src="_static/intel_logo.png" alt="Intel logo"></a>
             </div>
             <div class="col supporter">
-              <a href="https://www.nvidia.com/"><img src="_static/nvidia_logo.png"></a>
+              <a href="https://www.nvidia.com/"><img src="_static/nvidia_logo.png" alt="NVIDIA logo"></a>
             </div>
             <div class="col supporter">
-              <a href="https://www.amd.com"><img src="_static/amd_logo.png"></a>
+              <a href="https://www.amd.com"><img src="_static/amd_logo.png" alt="AMD logo"></a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR fixes https://github.com/numba/numba/issues/3984 by changing the broken link in the "SIMD learn more" section to point to http://numba.pydata.org/numba-doc/latest/user/performance-tips.html

I think that's fine for now, it fixes the bug. Of course more docs for SIMD might come in the future.

---

Another change here is to change the gray level when code examples are selected. See sceenshot below.

When I first looked at Numba I wanted to copy & paste from https://numba.pydata.org/
But it didn't seem to work, it seemed that it's not possible to select the code text there.
Actually it is, you just set the color of selected text to be the same as unselected text.
IMO this is confusing - thus this small adjustment.

---

Finally, I added two missing closing tags in the HTML (errors) and added alt to img tags (warnings) because my editor pointed those out.

---

![Screenshot 2019-05-07 at 14 54 43](https://user-images.githubusercontent.com/852409/57301104-7f26b200-70d8-11e9-9736-b610e96fa7a3.png)
